### PR TITLE
Import Meteor packages

### DIFF
--- a/apollo-accounts/src/Resolvers/oauth/loginWithGoogle.js
+++ b/apollo-accounts/src/Resolvers/oauth/loginWithGoogle.js
@@ -1,4 +1,5 @@
 import resolver from './resolver'
+import HTTP from 'meteor/http'
 
 const handleAuthFromAccessToken = function ({accessToken}) {
   const scopes = getScopes(accessToken)


### PR DESCRIPTION
I've seen that you are using global.* to include packages. Why not using import? This PR is not working, it's just an exmaple.

The advantage of this, is that Meteor knows what package is missing. I ran into this while updating my example app. 

I got messages like: 1114-12:33:06.212(1)? (STDERR) TypeError: Cannot read property 'secret' of undefined
1114-12:33:06.214(1)? (STDERR)     at module.export.exports.default (packages/nicolaslopezj:apollo-accounts/src/Res
s/oauth/resolver.js:11:29)

And the solution was to add the missing package.