### PR TITLE
remove error catcher

### DIFF
--- a/meteor-apollo-accounts/src/store.js
+++ b/meteor-apollo-accounts/src/store.js
@@ -4,11 +4,7 @@ const tokenDidChange = function () {
   // Looking for a better way to refetch all queries
   // window.location.reload(0)
   for (const callback of onChangeCallbacks) {
-    try {
-      callback()
-    } catch (error) {
-      console.log('Error on onChangeCallback', error)
-    }
+    callback()
   }
 }
 


### PR DESCRIPTION
wrapping the callback with a try/catch block will avoid the error from being caught by other error listeners (e.g. [trackjs](https://trackjs.com/)), bringing more harm than help.